### PR TITLE
Use env. variable instead of an expression in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -217,7 +217,7 @@ runs:
         echo ::group::Create Qlot Environment
 
         if [[ -n "${QLFILE_TEMPLATE}" ]]; then
-            echo "${QLFILE_TEMPLATE}" | ${{ github.action_path }}/templater.ros > qlfile
+            echo "${QLFILE_TEMPLATE}" | $GITHUB_ACTION_PATH/templater.ros > qlfile
             rm -f qlfile.lock
         fi
 


### PR DESCRIPTION
I think this should fix issue #7: `${{ github.action_path }}` includes  backslashes even when using bash on Windows. According to [this](https://github.com/orgs/community/discussions/25910) relying on the environment variable instead should work as expected.