### PR TITLE
Fixed loading of quicklisp-osx-fix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,14 +33,15 @@ jobs:
           - os: ubuntu-latest
             lisp: ecl
           - os: ubuntu-latest
-            lisp: allegro
-          - os: ubuntu-latest
             lisp: abcl-bin
           - os: ubuntu-latest
             lisp: clasp-bin
           - os: ubuntu-latest
             lisp: cmu-bin
 
+          # See issue: https://github.com/40ants/setup-lisp/issues/22
+          # - os: ubuntu-latest
+          #   lisp: allegro
           # See issue: https://github.com/40ants/setup-lisp/issues/15
           # - os: ubuntu-latest
           #   lisp: clisp

--- a/action.yml
+++ b/action.yml
@@ -272,20 +272,19 @@ runs:
         mkdir -p ~/.roswell
 
         cat >> ~/.roswell/init.lisp <<EOF
-        (handler-bind ((error #'(lambda (c)
-                                  (uiop:print-condition-backtrace c)
-                                  (uiop:quit 1))))
-          (let ((fix-filename (merge-pathnames
-                               (make-pathname :directory '(:relative ".quicklisp-client-fix")
-                                              :name "quicklisp-fix"
-                                              :type "lisp")
-                               (user-homedir-pathname))))
+        (let ((fix-filename (make-pathname :directory '(:absolute :home ".quicklisp-client-fix")
+                                           :name "quicklisp-fix"
+                                           :type "lisp")))
+          (let ((quicklisp-found #+quicklisp t
+                                 #-quicklisp nil))
             (cond
+              ((not quicklisp-found)
+               (warn "Quicklisp is not available, skipping fix loading.~%"))
               ((probe-file fix-filename)
-               (format t "Loading quicklisp fix.~%")
-               (load fix-filename))
+               (handler-bind ((warning #'muffle-warning))
+                 (load fix-filename)))
               (t
-               (format t "Quicklisp fix was not found at ~S.~%" fix-filename)))))
+               (warn "Quicklisp fix was not found at ~S.~%" fix-filename)))))
         EOF
        
     - if: inputs.cache == 'false' || steps.roswell-cache-restore.outputs.cache-hit != 'true'

--- a/changelog.lisp
+++ b/changelog.lisp
@@ -8,6 +8,12 @@
 (defchangelog (:ignore-words ("ASDF"
                               "PATH"
                               "HOME"))
+  (4.0.1 2024-02-25
+         "
+# Fixed
+
+* Fixed loading of quicklisp-osx-fix. Previously the script made unnecessary output and when you had a `qlfile` template in your workflow this output leaked into `qlfile` broking following `qlot install`.
+")
   (4.0.0 2024-02-24
          "
 # Changed

--- a/docs.lisp
+++ b/docs.lisp
@@ -93,7 +93,7 @@ when trying to call `ros` or `qlot` scripts:
 | **Implementation** | **Supported**                                        |
 |--------------------|------------------------------------------------------|
 | abcl-bin           | ✅                                                   |
-| allegro            | ✅ (sometimes fails because of \"expired-license\")  |
+| allegro            | [❌](https://github.com/40ants/setup-lisp/issues/22) |
 | ccl-bin            | ✅                                                   |
 | clasp              | [❌](https://github.com/40ants/setup-lisp/issues/16) |
 | clasp-bin          | ✅                                                   |


### PR DESCRIPTION
Previously the script made unnecessary output and when you had a `qlfile` template in your workflow this output leaked into `qlfile` broking following `qlot install`.