### PR TITLE
Extend cache key with runner architecture (fixes #32)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -211,7 +211,7 @@ runs:
       uses: actions/cache/restore@v4
       with:
         path: ${{ inputs.roswell-cache-paths }}
-        key: roswell-${{ inputs.roswell-version }}-${{ steps.locals.outputs.current-month }}-${{ env.cache-name }}-${{ runner.os }}-${{ env.LISP }}-${{ inputs.cache-suffix }}
+        key: roswell-${{ inputs.roswell-version }}-${{ steps.locals.outputs.current-month }}-${{ env.cache-name }}-${{ runner.os }}-${{ runner.arch }}-${{ env.LISP }}-${{ inputs.cache-suffix }}
 
     - if: inputs.cache == 'true' && steps.roswell-cache-restore.outputs.cache-hit == 'true'
       name: Restore Path To Cached Files


### PR DESCRIPTION
I didn't find anything in the default variables or in the runner context that refers to the OS version, but there's `runner.arch` which should at least solve the `macos-13` vs. `macos-14` issue.

Other projects seem to determine versions using OS-specific shell scripts: I'm not sure if it's worth the trouble in this case.