### PR TITLE
macos-14 caching fixes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,23 +52,42 @@ jobs:
             lisp: sbcl-bin
 
           # OSX
-          - os: macos-latest
+          - os: macos-13
             lisp: abcl-bin
-          - os: macos-latest
+          - os: macos-13
             lisp: ccl-bin
           # https://github.com/40ants/setup-lisp/issues/29
-          # - os: macos-latest
+          # - os: macos-13
           #   lisp: clasp-bin
           # https://github.com/40ants/setup-lisp/issues/28
-          # - os: macos-latest
+          # - os: macos-13
           #   lisp: clisp-head
           # https://github.com/40ants/setup-lisp/issues/30
-          # - os: macos-latest
+          # - os: macos-13
           #   lisp: cmu-bin
-          - os: macos-latest
+          - os: macos-13
             lisp: ecl
-          - os: macos-latest
+          - os: macos-13
             lisp: sbcl-bin
+
+          - os: macos-14
+            lisp: abcl-bin
+          # - os: macos-14
+          #   lisp: ccl-bin
+          # https://github.com/40ants/setup-lisp/issues/29
+          # - os: macos-14
+          #   lisp: clasp-bin
+          # https://github.com/40ants/setup-lisp/issues/28
+          # - os: macos-14
+          #   lisp: clisp-head
+          # https://github.com/40ants/setup-lisp/issues/30
+          # - os: macos-14
+          #   lisp: cmu-bin
+          - os: macos-14
+            lisp: ecl
+          - os: macos-14
+            lisp: sbcl-bin
+
 
           # Windows
 

--- a/action.yml
+++ b/action.yml
@@ -46,6 +46,8 @@ inputs:
       /usr/local/etc/roswell
       /usr/local/bin/ros
       /usr/local/Cellar/roswell
+      /opt/homebrew/bin/ros
+      /opt/homebrew/Cellar/roswell
 
   qlot-cache-paths:
     description: "Internal var. Don't use it."

--- a/action.yml
+++ b/action.yml
@@ -348,7 +348,7 @@ runs:
       uses: actions/cache/restore@v4
       with:
         path: ${{ inputs.qlot-cache-paths }}
-        key: qlot-${{ steps.locals.outputs.current-month }}-${{ env.cache-name }}-${{ runner.os }}-${{ env.QUICKLISP_DIST }}-${{ env.LISP }}-${{ hashFiles('qlfile', 'qlfile.lock', '*.asd') }}-${{ inputs.cache-suffix }}
+        key: qlot-${{ steps.locals.outputs.current-month }}-${{ env.cache-name }}-${{ runner.os }}-${{ runner.arch }}-${{ env.QUICKLISP_DIST }}-${{ env.LISP }}-${{ hashFiles('qlfile', 'qlfile.lock', '*.asd') }}-${{ inputs.cache-suffix }}
 
     - if: inputs.cache == 'true' && steps.qlot-cache-restore.outputs.cache-hit == 'true'
       name: Restore Path To .qlot/bin

--- a/changelog.lisp
+++ b/changelog.lisp
@@ -9,6 +9,15 @@
                               "PATH"
                               "CL"
                               "HOME"))
+
+  (4.0.5 2024-04-19
+         "
+# Fixed
+
+* Extended test matrix with macos-14 runner.
+* Fixed Roswell cache paths for macos-14 runner.
+* Extended qlot cache key with runner architecture.
+")
   (4.0.4 2024-04-18
          "
 # Fixed


### PR DESCRIPTION
Turns out there were more issues related to caching with the `macos-14` runner:

- The homebrew directory seems to have changed to `/opt/homebrew/`: I've extended `roswell-cache-paths` accordingly.
- The qlot step might involve compilation, so the architecture change can trip up some CL implementations when restoring a qlot cache from a different architecture: I've added `runner.arch` to the qlot cache key as well.